### PR TITLE
feat: pass window location hash to proxy

### DIFF
--- a/lka_tp.js
+++ b/lka_tp.js
@@ -1550,11 +1550,17 @@ function generateXMLmessage() {
   //Everything is ok. OnSubmit operation in <FORM>-tag is approved.
   //XML is sent to EBMeDS-engine.
 
-  // Send to test environment if YA
-  //if (window.location.hash === '#ya') {
-    document.LKAform.action = 'https://proxy-fikd7nv7fa-lz.a.run.app/lkatp/dssscripts/dss.asp'
-    document.LKAform.data.value = document.LKAform.dssData.value
-  //}
+  const EBMEDSProxyURL = 'https://proxy-fikd7nv7fa-lz.a.run.app/lkatp/dssscripts/dss.asp'
+  console.log(`EBMEDSProxyURL: ${EBMEDSProxyURL}`)
+  if (window.location.hash) {
+    const hashValue = window.location.hash.substring(1)
+    const newURL = `${EBMEDSProxyURL}?hash=${hashValue}`
+    console.log(`newURL: ${newURL}`)
+    document.LKAform.action = newURL
+  } else {
+    document.LKAform.action = EBMEDSProxyURL
+  }
+  document.LKAform.data.value = document.LKAform.dssData.value
 
   console.log(
     "Sending this xml to ebmeds engine:\n\n" +


### PR DESCRIPTION
# EBMEDS-9244

## Summary:

This pull request enables passing the window location hash as a query parameter hash to the EBMEDS proxy.

## Details:

The window location hash is now passed as a query parameter hash to the EBMEDS proxy.
Example: For the URL `https://www.terveysportti.fi/terveysportti/laake.lka.koti#foo`, the POST requests to the EBMEDS proxy will look like `<EBMEDSProxyURL>?hash=foo`.
This allows for modifying behavior at the proxy site based on the hash.

## Testing:

- Verified that the hash parameter is handled by the EBMEDS proxy without causing an outage.
- Confirmed that the behavior modification based on the hash works as expected by overriding the existing client side code.