### PR TITLE
fix: cmr crash

### DIFF
--- a/lka_tp.js
+++ b/lka_tp.js
@@ -2017,6 +2017,14 @@ $(document).ready(function () {
           if (typeof window.integrationResults.result[0].data[i].vnr !== 'undefined') {
             vnr = window.integrationResults.result[0].data[i].vnr[0];
           }
+          // POISTA LÄÄKKEET JOLLA EI OLE VAHVUUTTA
+          if (!window.integrationResults.result[0].data[i].strength) {
+            continue;
+          }
+          // KORJAA LÄÄKKEET JOISSA PILKKUVIRHE
+          if (window.integrationResults.result[0].data[i].strength.indexOf(",") === 0) {
+            window.integrationResults.result[0].data[i].strength = `0.${window.integrationResults.result[0].data[i].strength.slice(1)}`
+          }
           addTextInputDrug(
             "drugDiv",
             "lääkettä",


### PR DESCRIPTION
Medications with wrong values are crashing cmr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents medication entries without strength from appearing in the drug input list.
  * Automatically corrects malformed strength values that begin with a comma (e.g., “,5” becomes “0.5”) for consistency.
  * Sanitizes strength values before they are displayed or saved, improving reliability when adding medications.
  * Delivers cleaner, more accurate medication options and reduces input errors during entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->